### PR TITLE
Feat.new warning trigger setup

### DIFF
--- a/flash_flood_pipeline/data_upload/upload_results.py
+++ b/flash_flood_pipeline/data_upload/upload_results.py
@@ -235,6 +235,7 @@ class DataUploader:
                     "dynamicPointData": [
                         {"fid": int(fid), "value": True} for fid in exposed_fids
                     ],
+                    "date": self.date.strftime(format="%Y-%m-%dT%H:%M:%S.%fZ"),
                 }
                 api_post_request("point-data/dynamic", body=dynamic_post_body)
 
@@ -253,6 +254,7 @@ class DataUploader:
         exposed_roads_body["exposedFids"] = exposed_roads
         exposed_roads_body["linesDataCategory"] = "roads"
         exposed_roads_body["leadTime"] = self.lead_time
+        exposed_roads_body["date"] = self.date.strftime("%Y-%m-%dT%H:%M:%SZ")
         # logger.info(exposed_roads_body)
         api_post_request("lines-data/exposure-status", body=exposed_roads_body)
 
@@ -266,6 +268,7 @@ class DataUploader:
         exposed_buildings_body["exposedFids"] = exposed_buildings
         exposed_buildings_body["linesDataCategory"] = "buildings"
         exposed_buildings_body["leadTime"] = self.lead_time
+        exposed_buildings_body["date"] = self.date.strftime("%Y-%m-%dT%H:%M:%SZ")
         # logger.info(exposed_buildings_body)
         api_post_request("lines-data/exposure-status", body=exposed_buildings_body)
 

--- a/flash_flood_pipeline/data_upload/upload_results.py
+++ b/flash_flood_pipeline/data_upload/upload_results.py
@@ -74,7 +74,7 @@ class DataUploader:
         nr of affected schools, nr of affected clinics, nr of affected waterpoints, nr of affected buildings) for each TA by
         sending an API request (endpoint: admin-area-dynamic-data/exposure) and (2) triggering a TA when the value of the trigger
         exposure type is larger than the trigger threshold value (nr people affected >20), by sending an API-request (endpoint: admin-area-dynamic-data/exposure)
-        to the IBF-portal with the dynamic indicator "alert_threshold" = 1
+        to the IBF-portal
         """
         ta_exposure_trigger = self.TA_exposure.copy()
 
@@ -169,8 +169,23 @@ class DataUploader:
                         f"Posting: {distr_name} - leadtime = {self.lead_time} | {row['placeCode']} | {post_type}"
                     )
                                 
+                # forecast_severity: upload value=1 for all warned or triggered areas
                 body = TA_EXPOSURE_DICT
-                body["dynamicIndicator"] = "alert_threshold"
+                body["dynamicIndicator"] = "forecast_severity"
+                body["leadTime"] = self.lead_time
+                body["eventName"] = distr_name
+                body["exposurePlaceCodes"] = (
+                    exposed_tas[["placeCode"]]
+                    .assign(amount=1) # assuming this works, as non-warned/non-triggered areas are not part of this dict
+                    .dropna()
+                    .to_dict("records")
+                )
+                body["date"] = self.date.strftime("%Y-%m-%dT%H:%M:%SZ")
+                api_post_request("admin-area-dynamic-data/exposure", body=body)
+
+                # forecast_trigger
+                body = TA_EXPOSURE_DICT
+                body["dynamicIndicator"] = "forecast_trigger"
                 body["leadTime"] = self.lead_time
                 body["eventName"] = distr_name
                 body["exposurePlaceCodes"] = (
@@ -313,9 +328,21 @@ class DataUploader:
 
         api_post_request("admin-area-dynamic-data/exposure", body=body)
 
-        #############
+        # upload 'forecast_severity' with value 0 for all TA's
         body = TA_EXPOSURE_DICT
-        body["dynamicIndicator"] = "alert_threshold"
+        body["dynamicIndicator"] = "forecast_severity"
+        body["exposurePlaceCodes"] = (
+            untrigger_ta[["placeCode", "amount"]].dropna().to_dict("records")
+        )
+        body["leadTime"] = "1-hour"
+        body["date"] = self.date.strftime("%Y-%m-%dT%H:%M:%SZ")
+        body["eventName"] = None
+
+        api_post_request("admin-area-dynamic-data/exposure", body=body)
+        
+        # upload 'forecast_trigger' with value 0 for all TA's
+        body = TA_EXPOSURE_DICT
+        body["dynamicIndicator"] = "forecast_trigger"
         body["exposurePlaceCodes"] = (
             untrigger_ta[["placeCode", "amount"]].dropna().to_dict("records")
         )

--- a/flash_flood_pipeline/data_upload/upload_results.py
+++ b/flash_flood_pipeline/data_upload/upload_results.py
@@ -269,16 +269,6 @@ class DataUploader:
         # logger.info(exposed_buildings_body)
         api_post_request("lines-data/exposure-status", body=exposed_buildings_body)
 
-    def send_notifications(self):
-        """
-        Send notification email/whatsapp for all triggered areas by posting to notification/send endpoint
-        """
-        body = {
-            "countryCodeISO3": COUNTRY_CODE_ISO3,
-            "disasterType": DISASTER_TYPE,
-        }
-        api_post_request("notification/send", body=body)
-
     def upload_sensor_values(self):
         """
         upload sensor values to IBF system. Uses the point-data/dynamic endpoint to send:

--- a/flash_flood_pipeline/runPipeline.py
+++ b/flash_flood_pipeline/runPipeline.py
@@ -603,16 +603,18 @@ def main():
 
     logger.info("Closing Events...")
 
+    if ENVIRONMENT == "prod":
+        api_path = "events/process" #default for noNotifications=false
+    else:
+        api_path = "events/process?noNotifications=true"
     api_post_request(
-        "event/close-events",
+        api_path,
         body={
             "countryCodeISO3": "MWI",
             "disasterType": "flash-floods",
             "date": date.strftime("%Y-%m-%dT%H:%M:%SZ"),
         },
     )
-    if ENVIRONMENT == "prod":
-        gauge_data_uploader.send_notifications()
         
     elapsedTime = str(time.time() - startTime)
     logger.info(str(elapsedTime))


### PR DESCRIPTION
This PR changes the upload to IBF API in line with the recent datamodel changes there.

- Replace 'alert_threshold' layer by
  - 'forecast_severity' layer which is 1 if warned or triggered and 0 otherwise
  - 'forecast_trigger' layer which is 1 if triggered and 0 otherwise
- Replace API-calls /close-events + /notification/send by one API-call /events/process 

I have just made code changes and don't know how to functionally test this. Please do so @JanvE97 or @lokhorstivar. (The changes seem pretty straightforward though).